### PR TITLE
ENH: Update Slicer commit to latest hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY git://github.com/Slicer/Slicer
-    GIT_TAG        f4f510600a023120d5483a2310b609181cce4f72
+    GIT_TAG        d5373374f26741c78decac9fccdb69860faf0074
     GIT_PROGRESS   1
     )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY git://github.com/Slicer/Slicer
-    GIT_TAG        d5373374f26741c78decac9fccdb69860faf0074
+    GIT_TAG        39be4408f084b3e5d632b373a4985cd7fa6c661b
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
Updates the `slicersources` Slicer git tag to the latest commit tag.

Note that I got an error when trying to configure CMake from the previous commit hash, which does not seem to exist in the Slicer Github history? (https://github.com/Slicer/Slicer/commit/f4f510600a023120d5483a2310b609181cce4f72)[https://github.com/Slicer/Slicer/commit/f4f510600a023120d5483a2310b609181cce4f72] 

Probably best to tag for the 2019 blog after this change is committed.